### PR TITLE
ENH: Make handler allow handling of dask arrays

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,9 +3,6 @@ language: python
 matrix:
   fast_finish: true
   include:
-    - python: 2.7
-    - python: 3.4
-    - python: 3.5
     - python: 3.6
 
 install:

--- a/pygerm/caproto.py
+++ b/pygerm/caproto.py
@@ -58,7 +58,6 @@ class ChannelGeRMAcquireUDP(ca.ChannelData):
             else:
                 await zc.write(addr, val)
 
-
         filepath = _path_channel_to_Path(parent.filepath_channel)
         write_root = _path_channel_to_Path(parent.writeroot_channel)
         read_root = _path_channel_to_Path(parent.readroot_channel)
@@ -70,10 +69,10 @@ class ChannelGeRMAcquireUDP(ca.ChannelData):
         now = datetime.datetime.now()
         write_subdir = Path(f"{now.year}/{now.month}/{now.day}")
         write_subdir = filepath / write_subdir
-        #parent.filepath_channel.write(str(write_subdir))
+        # parent.filepath_channel.write(str(write_subdir))
 
-        #if write_path.is_absolute():
-            #raise Exception("write path must be not absolute")
+        # if write_path.is_absolute():
+        # raise Exception("write path must be not absolute")
 
         if not write_root.is_absolute():
             raise Exception("write root must be absolute")
@@ -87,7 +86,8 @@ class ChannelGeRMAcquireUDP(ca.ChannelData):
         if not dest_mount.is_absolute():
             raise Exception("destination mount point must be absolute")
 
-        await uc.ctrl_sock.send(str(write_root / str(uuid.uuid4())).encode('latin-1'))
+        await uc.ctrl_sock.send(str(write_root / str(uuid.uuid4()))
+                                .encode('latin-1'))
         resp = await uc.ctrl_sock.recv()
         if resp != b'Received Filename':
             print("DANGER WILL ROBINSON")
@@ -101,7 +101,7 @@ class ChannelGeRMAcquireUDP(ca.ChannelData):
         written_file = await uc.ctrl_sock.recv()
         # now need to add correct path given by filepath
         written_path = Path(written_file.decode())
-        
+
         # last file is last file on local server
         # TODO : change to server file is copied to?
         await parent.last_file_channel.write_from_dbr(
@@ -132,7 +132,8 @@ class ChannelGeRMAcquireUDP(ca.ChannelData):
 
         # relative filename needs to be filename on local server
         src_filename = src_mount / relative_filename
-        # write_filename is the desired filepath with relative path added from filepath
+        # write_filename is the desired filepath with relative path added from
+        # filepath
         dest_filename = dest_mount / write_filename
 
         # check if directory exists, if not make it

--- a/pygerm/caproto.py
+++ b/pygerm/caproto.py
@@ -72,7 +72,7 @@ class ChannelGeRMAcquireUDP(ca.ChannelData):
         # parent.filepath_channel.write(str(write_subdir))
 
         # if write_path.is_absolute():
-        # raise Exception("write path must be not absolute")
+        #     raise Exception("write path must be not absolute")
 
         if not write_root.is_absolute():
             raise Exception("write root must be absolute")

--- a/pygerm/client/__init__.py
+++ b/pygerm/client/__init__.py
@@ -7,6 +7,7 @@ TD_BITMASK = 0x1ff
 TS_BITMASK = 0x1fffffff
 PD_BITMASK = 0xfff
 
+
 def payload2event(data):
     '''Split up the raw data coming over the socket.
 
@@ -63,8 +64,9 @@ def event2payload(chip, chan, td, pd, ts):
     # word1 = data[::2]
     # word2 = data[1::2]
     # for word 1
-    payload[::2] = ((chip & CHIP_BITMASK) << 27) + ((chan & CHAN_BITMASK) << 22) + \
-        ((td & TD_BITMASK) << 12) + (pd & PD_BITMASK)
+    payload[::2] = ((chip & CHIP_BITMASK) << 27) + \
+                   ((chan & CHAN_BITMASK) << 22) + \
+                   ((td & TD_BITMASK) << 12) + (pd & PD_BITMASK)
 
     # for word 2
     payload[1::2] = (0x1 << 31) + (ts & TS_BITMASK)

--- a/pygerm/client/__init__.py
+++ b/pygerm/client/__init__.py
@@ -64,9 +64,9 @@ def event2payload(chip, chan, td, pd, ts):
     # word1 = data[::2]
     # word2 = data[1::2]
     # for word 1
-    payload[::2] = ((chip & CHIP_BITMASK) << 27) + \
-                   ((chan & CHAN_BITMASK) << 22) + \
-                   ((td & TD_BITMASK) << 12) + (pd & PD_BITMASK)
+    payload[::2] = (((chip & CHIP_BITMASK) << 27) +
+                    ((chan & CHAN_BITMASK) << 22) +
+                    ((td & TD_BITMASK) << 12) + (pd & PD_BITMASK))
 
     # for word 2
     payload[1::2] = (0x1 << 31) + (ts & TS_BITMASK)

--- a/pygerm/handler.py
+++ b/pygerm/handler.py
@@ -62,7 +62,6 @@ class BinaryGeRMHandler(HandlerBase):
             raise ValueError(msg)
 
         # remove first and last region
-        # if this is dask array, it's a lazy operation
         raw_data = raw_data[2:-2]
 
         # now the raw_data is a dask array, lazy loaded

--- a/pygerm/handler.py
+++ b/pygerm/handler.py
@@ -1,6 +1,7 @@
 from databroker.assets.handlers_base import HandlerBase
 import h5py
 import numpy as np
+import dask.array as da
 
 from .client import payload2event, DATA_TYPEMAP
 
@@ -22,28 +23,61 @@ class GeRMHandler(HandlerBase):
 class BinaryGeRMHandler(HandlerBase):
     specs = {'BinaryGeRM'}
 
-    def __init__(self, fpath):
-        # TODO : don't save the raw data (here for debugging)
-        raw_data = np.fromfile(fpath, dtype='>u4')
-        # TODO : when simulated data comes in, verify this is correct
-        # endianness and correct for it, don't just raise error
+    def __init__(self, fpath, chunksize=None):
+        ''' Binary GeRM handler.
+
+            Parameters
+            ----------
+            chunksize : int, optional
+                if specified, this turns result into a dask array
+                This array is a lazy loaded array. To obtain the results
+                one must call the .compute() method.
+                This is useful when the data is too large to fit in memory.
+
+            Notes
+            -----
+            When using chunksize, use functools.partial, and functools.wraps
+            Example:
+                from functools import partial, wraps
+                bgermdask = wraps(BinaryGeRMHandler)(partial(BinaryGeRMHandler,
+                                                             chunksize=100000))
+                fhandler_init = bgermdask(filename)
+                res = fhandler_init['germ_ts']
+                # etc...
+        '''
+        raw_data = np.memmap(fpath, dtype='>u4')
+
+        # now the raw_data is a dask array, lazy loaded
+        if chunksize is not None:
+            raw_data = da.from_array(raw_data, chunks=chunksize)
+
+        # verify the data
         first_word = raw_data[0]
+        last_word = raw_data[-1]
+        if chunksize is not None:
+            # if it's chunked data with dask array, compute
+            # since it is lazy
+            first_word = first_word.compute()
+            last_word = last_word.compute()
+
         if first_word != 0xfeedface:
             msg = "Error, first 32 bit word not 0xfeedface"
             msg += f"\n Got {first_word:#x} instead"
             raise ValueError(msg)
 
-        last_word = raw_data[-1]
         if last_word != 0xdecafbad:
             msg = "Error, first 32 bit word not 0xdecafbad"
             msg += f"\n Got {last_word:#x} instead"
             raise ValueError(msg)
 
         # remove first and last region
+        # if this is dask array, it's a lazy operation
         raw_data = raw_data[2:-2]
+        # this will work with lazy or non-lazy modes
         self.data = payload2event(raw_data)
 
     def __call__(self, column):
+        # NOTE: can return a lazy array
         return self.data[DATA_TYPEMAP[column]]
 
     def close(self):

--- a/pygerm/handler.py
+++ b/pygerm/handler.py
@@ -47,7 +47,6 @@ class BinaryGeRMHandler(HandlerBase):
         '''
         raw_data = np.memmap(fpath, dtype='>u4')
 
-
         # verify the data
         first_word = raw_data[0]
         last_word = raw_data[-1]

--- a/pygerm/handler.py
+++ b/pygerm/handler.py
@@ -26,39 +26,31 @@ class BinaryGeRMHandler(HandlerBase):
     def __init__(self, fpath, chunksize=None):
         ''' Binary GeRM handler.
 
-            Parameters
-            ----------
-            chunksize : int, optional
-                if specified, this turns result into a dask array
-                This array is a lazy loaded array. To obtain the results
-                one must call the .compute() method.
-                This is useful when the data is too large to fit in memory.
+        Parameters
+        ----------
+        chunksize : int, optional
+            if specified, this turns result into a dask array
+            This array is a lazy loaded array. To obtain the results
+            one must call the .compute() method.
+            This is useful when the data is too large to fit in memory.
 
-            Notes
-            -----
-            When using chunksize, use functools.partial, and functools.wraps
-            Example:
-                from functools import partial, wraps
-                bgermdask = wraps(BinaryGeRMHandler)(partial(BinaryGeRMHandler,
-                                                             chunksize=100000))
-                fhandler_init = bgermdask(filename)
-                res = fhandler_init['germ_ts']
-                # etc...
+        Notes
+        -----
+        When using chunksize, use functools.partial, and functools.wraps
+        Example ::
+            from functools import partial, wraps
+            bgermdask = wraps(BinaryGeRMHandler)(partial(BinaryGeRMHandler,
+                                                         chunksize=100000))
+            fhandler_init = bgermdask(filename)
+            res = fhandler_init['germ_ts']
+            # etc...
         '''
         raw_data = np.memmap(fpath, dtype='>u4')
 
-        # now the raw_data is a dask array, lazy loaded
-        if chunksize is not None:
-            raw_data = da.from_array(raw_data, chunks=chunksize)
 
         # verify the data
         first_word = raw_data[0]
         last_word = raw_data[-1]
-        if chunksize is not None:
-            # if it's chunked data with dask array, compute
-            # since it is lazy
-            first_word = first_word.compute()
-            last_word = last_word.compute()
 
         if first_word != 0xfeedface:
             msg = "Error, first 32 bit word not 0xfeedface"
@@ -73,6 +65,11 @@ class BinaryGeRMHandler(HandlerBase):
         # remove first and last region
         # if this is dask array, it's a lazy operation
         raw_data = raw_data[2:-2]
+
+        # now the raw_data is a dask array, lazy loaded
+        if chunksize is not None:
+            raw_data = da.from_array(raw_data, chunks=chunksize)
+
         # this will work with lazy or non-lazy modes
         self.data = payload2event(raw_data)
 

--- a/pygerm/reduction.py
+++ b/pygerm/reduction.py
@@ -1,9 +1,8 @@
 import pandas as pd
 import numpy as np
-import skimage
 from skimage.filters import threshold_otsu
-from skimage.transform import (hough_line, hough_line_peaks,
-                               probabilistic_hough_line)
+from skimage.transform import (hough_line, hough_line_peaks)
+import matplotlib.pyplot as plt
 
 
 def bin_frame(data, bins, corr_mat=None):

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,3 +2,4 @@ h5py
 numpy
 databroker
 zmq
+dask


### PR DESCRIPTION
Handling of large files using dask. Backwards compatible with previous usage. Here is the new usage:
```python
from pygerm.handler import BinaryGeRMHandler
from functools import partial, wraps
# max size is max number of elements
BinaryGeRMHandlerDask = wraps(BinaryGeRMHandler)(partial(BinaryGeRMHandler,
                                                         chunksize=1000000))
db.reg.register_handler('BinaryGeRM', BinaryGeRMHandlerDask, overwrite=True)
print("registered handler")
```

It works very well. I can load a 7 GB file chunk by chunk by accessing `data[a:b].compute()`. Note that `data` is a series of lazy operations (left shift and bitwise and) which is not computed until I run `compute`.


I couldn't think of any other way to do this without invoking `wraps` (to give the handler a `__name__`) and partial (so that I can pass the `chunksize` kwarg). Any thoughts @tacaswell @danielballan ? Is this the right way to think about handlers?